### PR TITLE
add default styling for GlueStack library

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -5,6 +5,7 @@ import { NavigationContainer } from '@react-navigation/native';
 import { createNativeStackNavigator } from '@react-navigation/native-stack';
 import { store } from './src/store/redux/store';
 import { selectIsAuthenticated } from "./src/store/redux/authSlice";
+import { config } from "@gluestack-ui/config";
 import { GluestackUIProvider } from "@gluestack-ui/themed";
 import { ApiProvider } from "@reduxjs/toolkit/query/react";
 import { movieApi } from "./src/store/redux/api";
@@ -17,7 +18,7 @@ function App() {
   const isAuthenticated = useSelector(selectIsAuthenticated);
 
   return (
-    < GluestackUIProvider>
+    < GluestackUIProvider config={config}>
       < NavigationContainer >
         <Stack.Navigator>
           {

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.0.1",
       "dependencies": {
         "@gluestack-style/react": "^1.0.48",
+        "@gluestack-ui/config": "^1.1.16",
         "@gluestack-ui/themed": "^1.1.9",
         "@react-navigation/native": "^6.1.14",
         "@react-navigation/native-stack": "^6.9.22",
@@ -2329,6 +2330,15 @@
       "peerDependencies": {
         "react": ">=16",
         "react-dom": ">=16"
+      }
+    },
+    "node_modules/@gluestack-ui/config": {
+      "version": "1.1.16",
+      "resolved": "https://registry.npmjs.org/@gluestack-ui/config/-/config-1.1.16.tgz",
+      "integrity": "sha512-oLdQEpCnOAYFskgk3whwIDZ3DmI9sAYf93LJB7qz+8VpOzSuoREq/hEL9Vtxk1BzioQDrjOB+FGLOpe+/vfJ9Q==",
+      "peerDependencies": {
+        "@gluestack-style/react": ">=1.0",
+        "@gluestack-ui/themed": ">=1.1"
       }
     },
     "node_modules/@gluestack-ui/divider": {

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   },
   "dependencies": {
     "@gluestack-style/react": "^1.0.48",
+    "@gluestack-ui/config": "^1.1.16",
     "@gluestack-ui/themed": "^1.1.9",
     "@react-navigation/native": "^6.1.14",
     "@react-navigation/native-stack": "^6.9.22",

--- a/src/screens/LoginScreen.tsx
+++ b/src/screens/LoginScreen.tsx
@@ -44,12 +44,18 @@ function LoginScreen() {
                 defaultValue=""
                 control={control}
                 render={({ field: { onBlur, onChange, value } }) => (
-                    <TextInput
+                <Input
+                    variant="outline"
+                    size="md"
+                    isDisabled={false}
+                    isInvalid={false}
+                    isReadOnly={false}>
+                    <InputField
                         placeholder="Username"
                         onBlur={onBlur}
                         onChangeText={onChange}
-                        value={value}
-                    />
+                        value={value} />
+                </Input>
                 )}
             />
             <Controller
@@ -57,12 +63,18 @@ function LoginScreen() {
                 defaultValue=""
                 control={control}
                 render={({ field: { onBlur, onChange, value } }) => (
-                    <TextInput
+                    <Input
+                    variant="outline"
+                    size="md"
+                    isDisabled={false}
+                    isInvalid={false}
+                    isReadOnly={false}>
+                    <InputField
                         placeholder="Password"
                         onBlur={onBlur}
                         onChangeText={onChange}
-                        value={value}
-                    />
+                        value={value} />
+                    </Input>
                 )}
             />
 


### PR DESCRIPTION
gluestack-ui is intentionally designed as an unstyled library, providing you with the flexibility to style your components as you prefer.
However, if you want to use the default theme, you can install @gluestack-ui/config.

https://gluestack.io/ui/docs/guides/install-rn